### PR TITLE
Add unschedule command

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,13 @@ Options:
   --help     Show this message and exit.
 
 Commands:
-  create    Create a new project
-  execute   Execute a flow from a project
-  login     Login to an Azkaban server
-  logout    Logout from Azkaban session
-  schedule  Schedule a flow from a project with specified...
-  upload    Generates a zip of path passed as argument...
+  create      Create a new project
+  execute     Execute a flow from a project
+  login       Login to an Azkaban server
+  logout      Logout from Azkaban session
+  schedule    Schedule a flow from a project with specified cron in quartz...
+  unschedule  Unschedule a flow from a project
+  upload      Generates a zip of path passed as argument and uploads it to...
 ```
 
 ## Examples

--- a/azkaban_cli/api.py
+++ b/azkaban_cli/api.py
@@ -104,6 +104,36 @@ def schedule_request(session, host, session_id, project, flow, cron, **execution
 
     return response
 
+def unschedule_request(session, host, session_id, schedule_id):
+    r"""Unschedule request for the Azkaban API
+
+    :param session: A session for creating the request
+    :type session: requests.Session
+    :param str host: Hostname where the request should go
+    :param str session_id: An id that the user should have when is logged in
+    :param str schedule_id: Schedule id of the flow that will be unscheduled on Azkaban
+    :return: The response from the request made
+    :rtype: requests.Response
+    :raises requests.exceptions.ConnectionError: if cannot connect to host
+    """
+
+    data = {
+        u'session.id': session_id,
+        u'action': u'removeSched',
+        u'scheduleId': schedule_id
+    }
+
+    logging.debug("Request data: \n%s", data)
+
+    response = session.post(
+        host + '/schedule',
+        data=data
+    )
+
+    logging.debug("Response: \n%s", response.text)
+
+    return response
+
 #TODO: Add optional parameters
 def execute_request(session, host, session_id, project, flow):
     """Execute request for the Azkaban API

--- a/azkaban_cli/azkaban.py
+++ b/azkaban_cli/azkaban.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import absolute_import
-from azkaban_cli.exceptions import NotLoggedOnError, SessionError, LoginError, UploadError, ScheduleError, ExecuteError, CreateError
+from azkaban_cli.exceptions import NotLoggedOnError, SessionError, LoginError, UploadError, ScheduleError, UnscheduleError, ExecuteError, CreateError
 from shutil import make_archive
 from urllib3.exceptions import InsecureRequestWarning
 import azkaban_cli.api as api
@@ -205,6 +205,34 @@ class Azkaban(object):
         response_json = response.json()
         logging.info(response_json[u'message'])
         logging.info('scheduleId: %s' % (response_json[u'scheduleId']))
+
+    def unschedule(self, schedule_id):
+        """Unschedule command, intended to make the request to Azkaban and treat the response properly.
+
+        This method receives the schedule id and optional execution options, makes the unschedule
+        request to unschedule the flow and evaluates the response.
+
+        If schedule_id is wrong or there is no session_id, it returns false. If everything is fine, returns
+        True.
+
+        :param schedule_id: Schedule id on Azkaban
+        :type schedule: str
+        :raises UnscheduleError: when Azkaban api returns error in response
+        """
+
+        self.__check_if_logged()
+
+        response = api.unschedule_request(
+            self.__session,
+            self.__host,
+            self.__session_id,
+            schedule_id
+        )
+
+        self.__catch_response_error(response, UnscheduleError)
+
+        response_json = response.json()
+        logging.info(response_json[u'message'])
 
     def execute(self, project, flow):
         """Execute command, intended to make the request to Azkaban and treat the response properly.

--- a/azkaban_cli/azkaban_cli.py
+++ b/azkaban_cli/azkaban_cli.py
@@ -8,7 +8,7 @@ import requests
 import sys
 import os
 from azkaban_cli.azkaban import Azkaban
-from azkaban_cli.exceptions import NotLoggedOnError, LoginError, SessionError, UploadError, ScheduleError, ExecuteError, CreateError
+from azkaban_cli.exceptions import NotLoggedOnError, LoginError, SessionError, UploadError, ScheduleError, UnscheduleError, ExecuteError, CreateError
 from azkaban_cli.__version__ import __version__
 
 APP_NAME = 'Azkaban CLI'
@@ -103,6 +103,15 @@ def __schedule(ctx, project, flow, cron, concurrent_option):
         logging.error(str(e))
 
 @login_required
+def __unschedule(ctx, schedule_id, concurrent_option):
+    azkaban = ctx.obj[u'azkaban']
+
+    try:
+        azkaban.unschedule(schedule_id, concurrentOption=concurrent_option)
+    except UnscheduleError as e:
+        logging.error(str(e))
+
+@login_required
 def __execute(ctx, project, flow):
     azkaban = ctx.obj[u'azkaban']
 
@@ -177,6 +186,13 @@ def schedule(ctx, project, flow, cron, concurrent_option):
     """Schedule a flow from a project with specified cron in quartz format"""
     __schedule(ctx, project, flow, cron, concurrent_option)
 
+@click.command(u'unschedule')
+@click.pass_context
+@click.argument(u'schedule_id', type=click.STRING)
+def unschedule(ctx, schedule_id):
+    """Unschedule a flow from a project"""
+    __unschedule(ctx, schedule_id)
+
 @click.command(u'execute')
 @click.pass_context
 @click.argument(u'project', type=click.STRING)
@@ -197,6 +213,7 @@ cli.add_command(login)
 cli.add_command(logout)
 cli.add_command(upload)
 cli.add_command(schedule)
+cli.add_command(unschedule)
 cli.add_command(execute)
 cli.add_command(create)
 

--- a/azkaban_cli/azkaban_cli.py
+++ b/azkaban_cli/azkaban_cli.py
@@ -103,7 +103,7 @@ def __schedule(ctx, project, flow, cron, concurrent_option):
         logging.error(str(e))
 
 @login_required
-def __unschedule(ctx, schedule_id, concurrent_option):
+def __unschedule(ctx, schedule_id):
     azkaban = ctx.obj[u'azkaban']
 
     try:

--- a/azkaban_cli/exceptions.py
+++ b/azkaban_cli/exceptions.py
@@ -18,5 +18,8 @@ class ExecuteError(Exception):
 class ScheduleError(Exception):
     pass
 
+class UnscheduleError(Exception):
+    pass
+
 class CreateError(Exception):
     pass

--- a/azkaban_cli/tests/test_azkaban/test_unschedule.py
+++ b/azkaban_cli/tests/test_azkaban/test_unschedule.py
@@ -1,0 +1,88 @@
+import os
+from unittest import TestCase
+from unittest.mock import patch, ANY
+
+import responses
+
+import azkaban_cli.azkaban
+from azkaban_cli.exceptions import UnscheduleError, SessionError
+
+
+class AzkabanUnscheduleTest(TestCase):
+    def setUp(self):
+        """
+        Creates an Azkaban instance and set a logged session for all upload tests
+        """
+
+        self.azk = azkaban_cli.azkaban.Azkaban()
+
+        self.host = 'http://azkaban-mock.com'
+        self.user = 'username'
+        self.session_id = 'aebe406b-d5e6-4056-add6-bf41091e42c6'
+
+        self.azk.set_logged_session(self.host, self.user, self.session_id)
+
+        self.schedule_id = '123'
+
+    def tearDown(self):
+        pass
+
+    @responses.activate
+    def test_unschedule(self):
+        """
+        Test unschedule method from Azkaban class
+        """
+
+        responses.add(
+            responses.POST,
+            self.host + "/schedule",
+            json={
+                'message': 'flow FLOW_NAME removed from Schedules.',
+                'status': 'success'
+            },
+            status=200
+        )
+
+        self.azk.unschedule(self.schedule_id)
+
+    @patch('azkaban_cli.azkaban.api.unschedule_request')
+    def test_unschedule_request_called(self, mock_unschedule_request):
+        """
+        Test if unschedule method from Azkaban class is calling unschedule request with expected arguments
+        """
+
+        self.azk.unschedule(self.schedule_id)
+
+        mock_unschedule_request.assert_called_with(ANY, self.host, self.session_id, self.schedule_id)
+
+    @responses.activate
+    def test_error_project_doesnt_exist_unschedule(self):
+        """
+        Test if unschedule method from Azkaban class raises UnscheduleError if request returns error caused by schedule ID doesn't exist
+        """
+
+        responses.add(
+            responses.POST,
+            self.host + "/schedule",
+            json={
+                'message': 'Schedule with ID SCHEDULE_ID does not exist',
+                'status': 'error'
+            },
+            status=200
+        )
+
+        with self.assertRaises(UnscheduleError):
+            self.azk.unschedule(self.schedule_id)
+
+    @responses.activate
+    def test_error_session_expired_unschedule(self):
+        """
+        Test if unschedule method from Azkaban class raises SessionError if request returns html from login because of expired session
+        """
+
+        fixture_path = os.path.join(os.path.dirname(__file__), os.pardir, "fixtures", "session_expired.html")
+        with open(fixture_path) as f:
+            responses.add(responses.POST, self.host + "/schedule", body=f.read(), status=200)
+
+        with self.assertRaises(SessionError):
+            self.azk.unschedule(self.schedule_id)


### PR DESCRIPTION
Add a new command `unschedule` that allows the user to unschedule a job flow on Azkaban. The command takes a `schedule_id` input parameter:
`azkaban unschedule 123`

This command calls this function in the Azkaban API: https://azkaban.github.io/azkaban/docs/latest/#api-unschedule-a-flow