### PR TITLE
Add delete request

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Options:
 
 Commands:
   create      Create a new project
+  delete      Delete a project
   execute     Execute a flow from a project
   login       Login to an Azkaban server
   logout      Logout from Azkaban session

--- a/azkaban_cli/api.py
+++ b/azkaban_cli/api.py
@@ -243,3 +243,28 @@ def create_request(session, host, session_id, project, description):
     logging.debug("Response: \n%s", response.text)
 
     return response
+
+def delete_request(session, host, session_id, project):
+    """Delete a Project request for the Azkaban API
+
+    :param session: A session for creating the request
+    :type session: requests.Session
+    :param str session_id: An id that the user should have when is logged in
+    :param str project: Project name to be deleted on Azkaban
+    :return: The response from the request made
+    :rtype: requests.Response
+    :raises requests.exceptions.ConnectionError: if cannot connect to host
+    """
+
+    response = session.get(
+        host + '/manager',
+        params={
+            u'session.id': session_id,
+            u'delete': 'true',
+            u'project': project
+        }
+    )
+
+    logging.debug("Response: \n%s", response.text)
+
+    return response

--- a/azkaban_cli/azkaban.py
+++ b/azkaban_cli/azkaban.py
@@ -71,12 +71,9 @@ class Azkaban(object):
         if response.text == "Login error. Need username and password":
             raise SessionError(response.text)
 
-    def __catch_login(self, response):
+    def __catch_response_error(self, response, exception):
         self.__catch_login_text(response)
         self.__catch_login_html(response)
-
-    def __catch_response_error(self, response, exception):
-        self.__catch_login(response)
 
         response_json = response.json()
 

--- a/azkaban_cli/azkaban.py
+++ b/azkaban_cli/azkaban.py
@@ -379,7 +379,7 @@ class Azkaban(object):
 
         self.__check_if_logged()
 
-        _ = api.delete_request(
+        api.delete_request(
             self.__session,
             self.__host,
             self.__session_id,

--- a/azkaban_cli/azkaban.py
+++ b/azkaban_cli/azkaban.py
@@ -382,12 +382,11 @@ class Azkaban(object):
 
         self.__check_if_logged()
 
-        response = api.delete_request(
+        _ = api.delete_request(
             self.__session,
             self.__host,
             self.__session_id,
             project
         )
 
-        # The delete request does not return any message, so we only catch login errors
-        self.__catch_login(response)
+        # The delete request does not return any message

--- a/azkaban_cli/azkaban.py
+++ b/azkaban_cli/azkaban.py
@@ -11,7 +11,8 @@ from azkaban_cli.exceptions import (
     FetchScheduleError,
     UnscheduleError,
     ExecuteError,
-    CreateError
+    CreateError,
+    DeleteError
 )
 from shutil import make_archive
 from urllib3.exceptions import InsecureRequestWarning
@@ -71,9 +72,12 @@ class Azkaban(object):
         if response.text == "Login error. Need username and password":
             raise SessionError(response.text)
 
-    def __catch_response_error(self, response, exception):
+    def __catch_login(self, response):
         self.__catch_login_text(response)
         self.__catch_login_html(response)
+
+    def __catch_response_error(self, response, exception):
+        self.__catch_login(response)
 
         response_json = response.json()
 
@@ -366,3 +370,26 @@ class Azkaban(object):
         self.__catch_response_error(response, CreateError)
 
         logging.info('Project %s created successfully' % (project))
+
+    def delete(self, project):
+        """Delete command, intended to make the request to Azkaban and treat the response properly.
+
+        This method receives the project name, make the execute request to delete the project and
+        evaluate the response.
+
+        :param project: Project name on Azkaban
+        :type project: str
+        """
+
+        self.__check_if_logged()
+
+        response = api.delete_request(
+            self.__session,
+            self.__host,
+            self.__session_id,
+            project
+        )
+
+        self.__catch_login(response)
+
+        logging.info('Command executed successfully')

--- a/azkaban_cli/azkaban.py
+++ b/azkaban_cli/azkaban.py
@@ -390,6 +390,7 @@ class Azkaban(object):
             project
         )
 
+        # The delete request does not return any message, so we only catch login errors
         self.__catch_login(response)
 
         logging.info('Command executed successfully')

--- a/azkaban_cli/azkaban.py
+++ b/azkaban_cli/azkaban.py
@@ -11,8 +11,7 @@ from azkaban_cli.exceptions import (
     FetchScheduleError,
     UnscheduleError,
     ExecuteError,
-    CreateError,
-    DeleteError
+    CreateError
 )
 from shutil import make_archive
 from urllib3.exceptions import InsecureRequestWarning
@@ -392,5 +391,3 @@ class Azkaban(object):
 
         # The delete request does not return any message, so we only catch login errors
         self.__catch_login(response)
-
-        logging.info('Command executed successfully')

--- a/azkaban_cli/azkaban_cli.py
+++ b/azkaban_cli/azkaban_cli.py
@@ -18,7 +18,8 @@ from azkaban_cli.exceptions import (
     FetchScheduleError,
     UnscheduleError,
     ExecuteError,
-    CreateError
+    CreateError,
+    DeleteError
 )
 from azkaban_cli.__version__ import __version__
 
@@ -147,6 +148,14 @@ def __create(ctx, project, description):
     except CreateError as e:
         logging.error(str(e))
 
+@login_required
+def __delete(ctx, project):
+    azkaban = ctx.obj[u'azkaban']
+    try:
+        azkaban.delete(project)
+    except DeleteError as e:
+        logging.error(str(e))
+
 
 # ----------------------------------------------------------------------------------------------------------------------
 # Interface
@@ -227,7 +236,14 @@ def execute(ctx, project, flow):
 @click.argument(u'description', type=click.STRING) 
 def create(ctx, project, description):
     """Create a new project"""
-    __create(ctx,project,description)
+    __create(ctx, project, description)
+
+@click.command(u'delete')
+@click.pass_context
+@click.argument(u'project', type=click.STRING)
+def delete(ctx, project):
+    """Delete a project"""
+    __delete(ctx, project)
 
 cli.add_command(login)
 cli.add_command(logout)
@@ -236,6 +252,7 @@ cli.add_command(schedule)
 cli.add_command(unschedule)
 cli.add_command(execute)
 cli.add_command(create)
+cli.add_command(delete)
 
 # ----------------------------------------------------------------------------------------------------------------------
 # Interface

--- a/azkaban_cli/exceptions.py
+++ b/azkaban_cli/exceptions.py
@@ -29,3 +29,6 @@ class UnscheduleError(Exception):
 
 class CreateError(Exception):
     pass
+
+class DeleteError(Exception):
+    pass

--- a/azkaban_cli/exceptions.py
+++ b/azkaban_cli/exceptions.py
@@ -29,6 +29,3 @@ class UnscheduleError(Exception):
 
 class CreateError(Exception):
     pass
-
-class DeleteError(Exception):
-    pass

--- a/azkaban_cli/tests/test_azkaban/test_delete.py
+++ b/azkaban_cli/tests/test_azkaban/test_delete.py
@@ -1,0 +1,80 @@
+import os
+from unittest import TestCase
+from unittest.mock import patch, ANY
+
+import responses
+
+import azkaban_cli.azkaban
+from azkaban_cli.exceptions import SessionError, DeleteError, NotLoggedOnError
+
+
+class AzkabanDeleteTest(TestCase):
+
+    def setUp(self):
+        """
+        Creates an Azkaban instance and set a logged session for all upload tests
+        """
+
+        self.azk = azkaban_cli.azkaban.Azkaban()
+
+        self.host = 'http://azkaban-mock.com'
+        self.user = 'username'
+        self.session_id = 'aebe406b-d5e6-4056-add6-bf41091e42c6'
+
+        self.azk.set_logged_session(self.host, self.user, self.session_id)
+
+        self.project = 'ProjectTest'
+
+    def tearDown(self):
+        pass
+
+    @responses.activate
+    def test_delete(self):
+        """
+        Test execute method from Azkaban class
+        """
+
+        responses.add(
+            responses.GET,
+            self.host + "/manager",
+            json={},
+            status=200
+        )
+
+        self.azk.delete(self.project)
+
+    @patch('azkaban_cli.azkaban.api.delete_request')
+    def test_delete_request_called(self, mock_delete_request):
+        """
+        Test if delete method from Azkaban class is calling delete request with expected arguments
+        """
+
+        self.azk.delete(self.project)
+
+        mock_delete_request.assert_called_with(ANY, self.host, self.session_id, self.project)
+
+    @responses.activate
+    def test_error_session_expired_delete(self):
+        """
+        Test if delete method from Azkaban class raises SessionError if request returns error caused by session expired
+        """
+
+        fixture_path = os.path.join(os.path.dirname(__file__), os.pardir, "fixtures", "session_expired.html")
+        with open(fixture_path) as f:
+            responses.add(responses.GET, self.host + "/manager", body=f.read(), status=200)
+
+        with self.assertRaises(SessionError):
+            self.azk.delete(self.project)
+
+    @patch('azkaban_cli.azkaban.api.delete_request')
+    def test_error_not_logged_delete(self, mock_delete_request):
+        """
+        Test if delete method from Azkaban class raises NotLoggedOnError and doesn't make the request if there is no logged session
+        """
+
+        self.azk.logout()
+
+        with self.assertRaises(NotLoggedOnError):
+            self.azk.delete('project')
+
+        mock_delete_request.assert_not_called()

--- a/azkaban_cli/tests/test_azkaban/test_delete.py
+++ b/azkaban_cli/tests/test_azkaban/test_delete.py
@@ -53,19 +53,6 @@ class AzkabanDeleteTest(TestCase):
 
         mock_delete_request.assert_called_with(ANY, self.host, self.session_id, self.project)
 
-    @responses.activate
-    def test_error_session_expired_delete(self):
-        """
-        Test if delete method from Azkaban class raises SessionError if request returns error caused by session expired
-        """
-
-        fixture_path = os.path.join(os.path.dirname(__file__), os.pardir, "fixtures", "session_expired.html")
-        with open(fixture_path) as f:
-            responses.add(responses.GET, self.host + "/manager", body=f.read(), status=200)
-
-        with self.assertRaises(SessionError):
-            self.azk.delete(self.project)
-
     @patch('azkaban_cli.azkaban.api.delete_request')
     def test_error_not_logged_delete(self, mock_delete_request):
         """

--- a/azkaban_cli/tests/test_azkaban/test_delete.py
+++ b/azkaban_cli/tests/test_azkaban/test_delete.py
@@ -5,7 +5,7 @@ from unittest.mock import patch, ANY
 import responses
 
 import azkaban_cli.azkaban
-from azkaban_cli.exceptions import SessionError, DeleteError, NotLoggedOnError
+from azkaban_cli.exceptions import SessionError, NotLoggedOnError
 
 
 class AzkabanDeleteTest(TestCase):


### PR DESCRIPTION
This PR adds a `delete` command to the azkaban CLI as referenced in the [API documentation](https://azkaban.github.io/azkaban/docs/latest/#api-delete-a-project). The command is invoked as follows:
`azkaban delete PROJECT`