### PR TITLE
Add fetch all projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Options:
 Commands:
   create      Create a new project
   execute     Execute a flow from a project
+  fetch_projects  Fetch all project from a user
   login       Login to an Azkaban server
   logout      Logout from Azkaban session
   schedule    Schedule a flow from a project with specified cron in quartz...

--- a/azkaban_cli/api.py
+++ b/azkaban_cli/api.py
@@ -257,7 +257,10 @@ def fetch_projects_request(session, host, session_id):
     """
 
     response = session.get(
-        host + '/index?all'
+        host + '/index?all',
+        params={
+            u'session.id': session_id
+        }
     )
 
     logging.debug("Response: \n%s", response.text)

--- a/azkaban_cli/api.py
+++ b/azkaban_cli/api.py
@@ -243,3 +243,23 @@ def create_request(session, host, session_id, project, description):
     logging.debug("Response: \n%s", response.text)
 
     return response
+
+def fetch_projects_request(session, host, session_id):
+    """Fetch all projects request for the Azkaban API
+
+    :param session: A session for creating the request
+    :type session: requests.Session
+    :param str host: Hostname where the request should go
+    :param str session_id: An id that the user should have when is logged in
+    :return: The response from the request made
+    :rtype: requests.Response
+    :raises requests.exceptions.ConnectionError: if cannot connect to host
+    """
+
+    response = session.get(
+        host + '/index?all'
+    )
+
+    logging.debug("Response: \n%s", response.text)
+
+    return response

--- a/azkaban_cli/azkaban.py
+++ b/azkaban_cli/azkaban.py
@@ -386,7 +386,7 @@ class Azkaban(object):
             self.__session_id
         )
 
-        # The delete request does not return any message, so we only catch login errors
+        # The fetch projects request returns an html content, so we only catch login errors
         self.__catch_login(response)
 
         return response.text

--- a/azkaban_cli/azkaban.py
+++ b/azkaban_cli/azkaban.py
@@ -386,8 +386,7 @@ class Azkaban(object):
             self.__session_id
         )
 
+        # The delete request does not return any message, so we only catch login errors
         self.__catch_login(response)
 
-        # response_json = response.json()
-        # return response_json
         return response.text

--- a/azkaban_cli/azkaban.py
+++ b/azkaban_cli/azkaban.py
@@ -70,10 +70,13 @@ class Azkaban(object):
     def __catch_login_text(self, response):
         if response.text == "Login error. Need username and password":
             raise SessionError(response.text)
-
-    def __catch_response_error(self, response, exception):
+    
+    def __catch_login(self, response):
         self.__catch_login_text(response)
         self.__catch_login_html(response)
+
+    def __catch_response_error(self, response, exception):
+        self.__catch_login(response)
 
         response_json = response.json()
 
@@ -366,3 +369,25 @@ class Azkaban(object):
         self.__catch_response_error(response, CreateError)
 
         logging.info('Project %s created successfully' % (project))
+
+    def fetch_projects(self):
+        """Fetch all projects command, intended to make the request to Azkaban and treat the response properly.
+
+        This method makes the fetch projects request to fetch all the projects and evaluates the response.
+
+        :raises FetchFlowsError: when Azkaban api returns error in response
+        """
+
+        self.__check_if_logged()
+
+        response = api.fetch_projects_request(
+            self.__session,
+            self.__host,
+            self.__session_id
+        )
+
+        self.__catch_login(response)
+
+        # response_json = response.json()
+        # return response_json
+        return response.text

--- a/azkaban_cli/azkaban_cli.py
+++ b/azkaban_cli/azkaban_cli.py
@@ -171,9 +171,12 @@ def __parse_projects(text, user):
 @login_required
 def __fetch_projects(ctx):
     azkaban = ctx.obj[u'azkaban']
-    text = azkaban.fetch_projects()
-    user = ctx.obj[u'user']
-    __parse_projects(text, user)
+    try:
+        text = azkaban.fetch_projects()
+        user = ctx.obj[u'user']
+        __parse_projects(text, user)
+    except FetchProjectsError as e:
+        logging.error(str(e))
 
 
 # ----------------------------------------------------------------------------------------------------------------------

--- a/azkaban_cli/azkaban_cli.py
+++ b/azkaban_cli/azkaban_cli.py
@@ -265,7 +265,7 @@ def create(ctx, project, description):
 @click.pass_context
 @click.option(u'--user', type=click.STRING, required=False, help=u'Azkaban user to fetch projects from')
 def fetch_projects(ctx, user):
-    """Fetch all project"""
+    """Fetch all project from a user"""
     __fetch_projects(ctx, user)
 
 cli.add_command(login)

--- a/azkaban_cli/azkaban_cli.py
+++ b/azkaban_cli/azkaban_cli.py
@@ -169,11 +169,12 @@ def __parse_projects(text, user):
         raise FetchProjectsError('Error parsing response')
 
 @login_required
-def __fetch_projects(ctx):
+def __fetch_projects(ctx, user):
     azkaban = ctx.obj[u'azkaban']
     try:
         text = azkaban.fetch_projects()
-        user = ctx.obj[u'user']
+        if not user:
+            user = ctx.obj[u'user']
         __parse_projects(text, user)
     except FetchProjectsError as e:
         logging.error(str(e))
@@ -262,9 +263,10 @@ def create(ctx, project, description):
 
 @click.command(u'fetch_projects')
 @click.pass_context
-def fetch_projects(ctx):
+@click.option(u'--user', type=click.STRING, required=False, help=u'Azkaban user to fetch projects from')
+def fetch_projects(ctx, user):
     """Fetch all project"""
-    __fetch_projects(ctx)
+    __fetch_projects(ctx, user)
 
 cli.add_command(login)
 cli.add_command(logout)

--- a/azkaban_cli/azkaban_cli.py
+++ b/azkaban_cli/azkaban_cli.py
@@ -83,7 +83,6 @@ def __login(ctx, host, user, password):
     try:
         azkaban.login(host, user, password)
         __save_logged_session(azkaban.get_logged_session())
-        ctx.obj[u'user'] = user
         logging.info("Logged in successfully!")
     except (requests.exceptions.ConnectionError, requests.exceptions.MissingSchema) as e:
         logging.error("Could not connect to host: %s", str(e))
@@ -171,10 +170,12 @@ def __parse_projects(text, user):
 @login_required
 def __fetch_projects(ctx, user):
     azkaban = ctx.obj[u'azkaban']
+
+    if not user:
+        user = azkaban.get_logged_session().get(u'user')
+
     try:
         text = azkaban.fetch_projects()
-        if not user:
-            user = ctx.obj[u'user']
         __parse_projects(text, user)
     except FetchProjectsError as e:
         logging.error(str(e))

--- a/azkaban_cli/azkaban_cli.py
+++ b/azkaban_cli/azkaban_cli.py
@@ -19,7 +19,8 @@ from azkaban_cli.exceptions import (
     FetchScheduleError,
     UnscheduleError,
     ExecuteError,
-    CreateError
+    CreateError,
+    FetchProjectsError
 )
 from azkaban_cli.__version__ import __version__
 
@@ -156,13 +157,16 @@ def __parse_projects(text, user):
     def get_user(div):
         return div.find_all('p', {'class': 'project-last-modified'})[0].text.split('\n')[-1].strip()[:-1]
 
-    soup = BeautifulSoup(text, 'html.parser')
-    all_projects = soup.find_all('div', {'class': 'project-info'})
-    all_projects_for_user = [get_text(div) for div in all_projects if get_user(div) == user]
-    logging.info('Found %d projects for user %s:' % (len(all_projects_for_user), user))
+    try:
+        soup = BeautifulSoup(text, 'html.parser')
+        all_projects = soup.find_all('div', {'class': 'project-info'})
+        all_projects_for_user = [get_text(div) for div in all_projects if get_user(div) == user]
+        logging.info('Found %d projects for user %s:' % (len(all_projects_for_user), user))
 
-    for project in all_projects_for_user:
-        logging.info('- %s' % (project))
+        for project in all_projects_for_user:
+            logging.info('- %s' % (project))
+    except:
+        raise FetchProjectsError('Error parsing response')
 
 @login_required
 def __fetch_projects(ctx):

--- a/azkaban_cli/exceptions.py
+++ b/azkaban_cli/exceptions.py
@@ -29,3 +29,6 @@ class UnscheduleError(Exception):
 
 class CreateError(Exception):
     pass
+
+class FetchProjectsError(Exception):
+    pass

--- a/azkaban_cli/tests/test_azkaban/test_fetch_projects.py
+++ b/azkaban_cli/tests/test_azkaban/test_fetch_projects.py
@@ -47,14 +47,3 @@ class AzkabanFetchProjectsTest(TestCase):
         self.azk.fetch_projects()
 
         mock_fetch_projects_request.assert_called_with(ANY, self.host, self.session_id)
-
-    @responses.activate
-    def test_error_session_expired_fetch_projects(self):
-        """
-        Test if fetch projects method from Azkaban class raises SessionError if request returns error caused by session expired
-        """
-
-        responses.add(responses.GET, self.host + "/index", json={"error": "session"}, status=200)
-
-        with self.assertRaises(SessionError):
-            self.azk.fetch_projects()

--- a/azkaban_cli/tests/test_azkaban/test_fetch_projects.py
+++ b/azkaban_cli/tests/test_azkaban/test_fetch_projects.py
@@ -1,5 +1,6 @@
 from unittest import TestCase
 from unittest.mock import patch, ANY
+import os
 
 import responses
 
@@ -54,9 +55,9 @@ class AzkabanFetchProjectsTest(TestCase):
         Test if fetch projects method from Azkaban class raises SessionError if request returns error caused by session expired
         """
 
-        body = '  <script type=\"text/javascript\" src=\"/js/azkaban/view/login.js\"></script>'
-
-        responses.add(responses.GET, self.host + "/index", body=body, status=200)
+        fixture_path = os.path.join(os.path.dirname(__file__), os.pardir, "fixtures", "session_expired.html")
+        with open(fixture_path) as f:
+            responses.add(responses.GET, self.host + "/index", body=f.read(), status=200)
 
         with self.assertRaises(SessionError):
             self.azk.fetch_projects()

--- a/azkaban_cli/tests/test_azkaban/test_fetch_projects.py
+++ b/azkaban_cli/tests/test_azkaban/test_fetch_projects.py
@@ -32,7 +32,7 @@ class AzkabanFetchProjectsTest(TestCase):
 
         responses.add(
             responses.GET,
-            self.host + "/index?all",
+            self.host + "/index",
             status=200
         )
 
@@ -47,3 +47,16 @@ class AzkabanFetchProjectsTest(TestCase):
         self.azk.fetch_projects()
 
         mock_fetch_projects_request.assert_called_with(ANY, self.host, self.session_id)
+
+    @responses.activate
+    def test_error_session_expired_fetch_projects(self):
+        """
+        Test if fetch projects method from Azkaban class raises SessionError if request returns error caused by session expired
+        """
+
+        body = '  <script type=\"text/javascript\" src=\"/js/azkaban/view/login.js\"></script>'
+
+        responses.add(responses.GET, self.host + "/index", body=body, status=200)
+
+        with self.assertRaises(SessionError):
+            self.azk.fetch_projects()

--- a/azkaban_cli/tests/test_azkaban/test_fetch_projects.py
+++ b/azkaban_cli/tests/test_azkaban/test_fetch_projects.py
@@ -1,0 +1,60 @@
+from unittest import TestCase
+from unittest.mock import patch, ANY
+
+import responses
+
+import azkaban_cli.azkaban
+from azkaban_cli.exceptions import SessionError
+
+
+class AzkabanFetchProjectsTest(TestCase):
+    def setUp(self):
+        """
+        Creates an Azkaban instance and set a logged session for all fetch flows tests
+        """
+
+        self.azk = azkaban_cli.azkaban.Azkaban()
+
+        self.host = 'http://azkaban-mock.com'
+        self.user = 'username'
+        self.session_id = 'aebe406b-d5e6-4056-add6-bf41091e42c6'
+
+        self.azk.set_logged_session(self.host, self.user, self.session_id)
+
+    def tearDown(self):
+        pass
+
+    @responses.activate
+    def test_fetch_projects(self):
+        """
+        Test fetch projects method from Azkaban class
+        """
+
+        responses.add(
+            responses.GET,
+            self.host + "/index?all",
+            status=200
+        )
+
+        self.azk.fetch_projects()
+
+    @patch('azkaban_cli.azkaban.api.fetch_projects_request')
+    def test_fetch_projects_request_called(self, mock_fetch_projects_request):
+        """
+        Test if fetch projects method from Azkaban class is calling fetch projects request with expected arguments
+        """
+
+        self.azk.fetch_projects()
+
+        mock_fetch_projects_request.assert_called_with(ANY, self.host, self.session_id)
+
+    @responses.activate
+    def test_error_session_expired_fetch_projects(self):
+        """
+        Test if fetch projects method from Azkaban class raises SessionError if request returns error caused by session expired
+        """
+
+        responses.add(responses.GET, self.host + "/index", json={"error": "session"}, status=200)
+
+        with self.assertRaises(SessionError):
+            self.azk.fetch_projects()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 requests<2.30.0
 click<8.0
 responses==0.10.5
-beautifulsoup4
+beautifulsoup4<=4.7.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 requests<2.30.0
 click<8.0
 responses==0.10.5
+beautifulsoup4


### PR DESCRIPTION
This PR adds a `fetch_projects` command to the azkaban CLI that lists all projects owned by the current user. An optional argument `--user USER` can be used to fetch all projects from the specified user.
`azkaban fetch_projects [--user USER]`