### PR TITLE
Fix permission setting error in Python2

### DIFF
--- a/azkaban_cli/azkaban.py
+++ b/azkaban_cli/azkaban.py
@@ -519,21 +519,24 @@ class Azkaban(object):
         logging.info('Group [%s] AAA received new permissions [%s] in the Project [%s] successfully' % (group, permission_options, project))
 
     def __check_group_permissions(self, permission_options):
-        
-        options = ["admin", "write", "read", "execute", "schedule"]
-        empty_permission_options = {option: False for option in options}
+        __options = ["admin", "write", "read", "execute", "schedule"]
+        filled_permission_options = {
+            option: permission_options[option] if option in permission_options else False for option in __options
+        }
 
-        filled_permission_options = {**empty_permission_options, **permission_options}
-
-        have_declared_options = filled_permission_options['admin'] and filled_permission_options['read'] and filled_permission_options['write'] \
-        and filled_permission_options['execute'] and filled_permission_options['schedule']
+        have_declared_options = \
+            filled_permission_options['admin'] and \
+            filled_permission_options['read'] and \
+            filled_permission_options['write'] and \
+            filled_permission_options['execute'] and \
+            filled_permission_options['schedule']
 
         #if we have the admin opt, then all be true
         if filled_permission_options['admin']:
-            filled_permission_options = {key: True for key in filled_permission_options}
+            filled_permission_options = {option: True for option in filled_permission_options}
 
         #if we don`t have declared options, then we have to set the read option as default, like in the Azkaban web-ui
         elif not have_declared_options:
             filled_permission_options['read'] = True
-        
+
         return filled_permission_options

--- a/azkaban_cli/azkaban_cli.py
+++ b/azkaban_cli/azkaban_cli.py
@@ -232,7 +232,11 @@ def __add_permission(ctx, project, group, admin, read, write, _execute, _schedul
             project, 
             group, 
             permission_options= {
-                'admin':admin, 'read':read, 'write':write, 'execute':_execute, 'schedule': _schedule
+                'admin': admin,
+                'read': read,
+                'write': write,
+                'execute': _execute,
+                'schedule': _schedule
             }
         )
     except AddPermissionError as e:
@@ -257,7 +261,11 @@ def __change_permission(ctx, project, group, admin, read, write, _execute, _sche
             project, 
             group, 
             permission_options= {
-                'admin':admin, 'read':read, 'write':write, 'execute':_execute, 'schedule': _schedule
+                'admin': admin,
+                'read': read,
+                'write': write,
+                'execute': _execute,
+                'schedule': _schedule
             }
         )
     except ChangePermissionError as e:

--- a/azkaban_cli/tests/test_azkaban/test_add_permission.py
+++ b/azkaban_cli/tests/test_azkaban/test_add_permission.py
@@ -22,7 +22,9 @@ class AzkabanAddPermissionTest(TestCase):
 
         self.project = 'ProjectTest'
         self.group   = 'GroupTest'
-        self.permission_options = {'admin': False, 'read': True, 'write': False, 'execute': False, 'schedule': False}
+        self.permission_options = {
+            'admin': False, 'read': True, 'write': False, 'execute': False, 'schedule': False
+        }
 
     def tearDown(self):
         pass


### PR DESCRIPTION
Previous version of code has a dictionary expansion rule that works on Python3 but fails in Python2. This PR fixes this issue by using a dict comprehension instead.
Also includes a couple of formatting tweaks.