### PR TITLE
add api methods to read the docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,24 @@
+# Documentation process
+
+The methods who are beeen documented here are the ones that the user uses to interact with the api. Those methoods belogs to the Azkaban object described in ``azkaban.py``
+
+## How to build the documentation locally
+
+Make sure to have a ``virtualenv`` active and simply download Sphinx by typing ``pip install sphinx``. Once installed run ``make html`` within the folder with the ``Makefile`` to build your local version of the documentation inside ``build/html/index.html``.
+
+## How to document a new method.
+
+Once have added a new API call method inside azkaban.py and made sure to had written the appropriate docstring, go to the ``index.srt`` and add:
+
+````
+your method's name
+-------------------
+
+.. autoclass:: azkaban_cli.azkaban.Azkaban.your_method_name
+````
+
+to the end of the file.
+
+It will automatically generate the documentation from that particular method based upon the docstring you wrote.
+
+Keep in mind that sphinx interprets your documentation as python code, so any code lying outside a method or a class may be called by the sphinx builder including the import statements. You may have to pip install some of those before being able to correctly build your documentation file.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,9 +12,9 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-# import os
-# import sys
-# sys.path.insert(0, os.path.abspath('.'))
+import os
+import sys
+sys.path.insert(0, os.path.abspath('..'))
 
 
 # -- Project information -----------------------------------------------------
@@ -43,7 +43,8 @@ extensions = [
     'sphinx.ext.intersphinx',
     'sphinx.ext.ifconfig',
     'sphinx.ext.viewcode',
-    'sphinx.ext.githubpages'
+    'sphinx.ext.githubpages',
+    'sphinx_rtd_theme'
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -79,7 +80,7 @@ pygments_style = None
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'alabaster'
+html_theme = 'sphinx_rtd_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,7 +17,7 @@ Azkaban CLI
 CLI for Azkaban 3 API access and flow upload.
 
 Installation
--------
+------------
 
 Please virtualenv or conda env on this, example as follows
 
@@ -64,7 +64,7 @@ Activate your virtualenv and call ``azkaban``
      upload                Generates a zip of path passed as argument and...
 
 Examples
----------
+--------
 
 Making Login
 ^^^^^^^^^^^^
@@ -79,3 +79,74 @@ Contribute
 ----------
 
 For development and contributing, please follow `Contributing Guide <https://github.com/globocom/azkaban-cli/blob/master/CONTRIBUTING.md>`_ and ALWAYS respect the `Code of Conduct <https://github.com/globocom/azkaban-cli/blob/master/CODE_OF_CONDUCT.md>`_
+
+
+API Methods
+===========
+
+login
+-----
+.. autoclass:: azkaban_cli.azkaban.Azkaban.login
+
+
+logout
+------
+.. autoclass:: azkaban_cli.azkaban.Azkaban.logout
+
+
+upload
+------
+.. autoclass:: azkaban_cli.azkaban.Azkaban.upload
+
+
+create
+------
+.. autoclass:: azkaban_cli.azkaban.Azkaban.create
+
+
+delete
+------
+.. autoclass:: azkaban_cli.azkaban.Azkaban.delete
+
+add_permission
+--------------
+.. autoclass:: azkaban_cli.azkaban.Azkaban.add_permission
+
+change_permission
+-----------------
+.. autoclass:: azkaban_cli.azkaban.Azkaban.change_permission
+
+remove_permission
+-----------------
+.. autoclass:: azkaban_cli.azkaban.Azkaban.remove_permission
+
+execute
+-------
+.. autoclass:: azkaban_cli.azkaban.Azkaban.execute
+
+fetch_projects
+--------------
+.. autoclass:: azkaban_cli.azkaban.Azkaban.fetch_projects
+
+fetch_sla
+---------
+.. autoclass:: azkaban_cli.azkaban.Azkaban.fetch_sla
+
+fetch_flow_execution
+--------------------
+.. autoclass:: azkaban_cli.azkaban.Azkaban.fetch_flow_execution
+
+fetch_jobs_from_flow
+--------------------
+.. autoclass:: azkaban_cli.azkaban.Azkaban.fetch_jobs_from_flow
+
+schedule
+--------
+.. autoclass:: azkaban_cli.azkaban.Azkaban.schedule
+
+unschedule
+----------
+.. autoclass:: azkaban_cli.azkaban.Azkaban.unschedule
+
+
+

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+Sphinx==2.2.0
+sphinx-rtd-theme


### PR DESCRIPTION
I've added the ``.. autoclass::`` to all the API methods that could ben called by the user in order to explain the methods used to interact with Azkaban. 

I also took the liberty to chose a different theme for the documentation. ``sphinx.ext.githubpages``

![readthedocs](https://user-images.githubusercontent.com/18516908/66265146-a993ad00-e7e7-11e9-9886-93a4f42c0f96.png)

I've decided to display each method of the Azkaban class 'manually' by calling:
````.. autoclass:: azkaban_cli.azkaban.Azkaban.methood````
That way I could put a title in each one of them to make it easy to find it on the sidebar.

This approach creates the needing to add all the new methods, 'manually'.
I could been used:
````
.. autoclass:: azkaban_cli.azkaban.Azkaban
 :members:
````
To load all the methods automatically and avoid the downsizing of the approach described above but I've prioritized documentation readability and navigation. 