### PR TITLE
Removed unnecessary syntax highlighting from Readme.md [Usage section]

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ Activate your virtualenv and call ```azkaban```
 ```sh
 $ azkaban --help
 Usage: azkaban [OPTIONS] COMMAND1 [ARGS]... [COMMAND2 [ARGS]...]...
-
+```
+```
 Options:
   --version  Show the version and exit.
   --help     Show this message and exit.

--- a/README.md
+++ b/README.md
@@ -21,11 +21,10 @@ pip install azkaban_cli
 
 Activate your virtualenv and call ```azkaban```
 
-```sh
+```
 $ azkaban --help
 Usage: azkaban [OPTIONS] COMMAND1 [ARGS]... [COMMAND2 [ARGS]...]...
-```
-```
+
 Options:
   --version  Show the version and exit.
   --help     Show this message and exit.


### PR DESCRIPTION
As described in the issue this fixes the irrelevant syntax highlighting and makes sure no information is lost in the way.

So, removed shell command highlighting from Usage section (2nd code snippet).

Fixes: #55 