### PR TITLE
add fetch running executions of a flow api call

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Commands:
   delete                              Delete a project
   execute                             Execute a flow from a project
   cancel                              Cancel a flow execution
-  fetch_running_executions_of_a_flow  Fetch the current running executions of a flow
+  fetch_running_executions_of_a_flow  Fetch the running executions of a flow
   fetch_flow_execution                Fetch a flow execution
   fetch_flow_execution_updates        Fetch flow execution updates
   fetch_execution_of_a_flow           Fetch all execution of a given flow

--- a/README.md
+++ b/README.md
@@ -31,26 +31,26 @@ Options:
   --help     Show this message and exit.
 
 Commands:
-  add_permission                Add a group with permission in a project
-  change_permission             Change a group permission in a project
-  create                        Create a new project
-  delete                        Delete a project
-  execute                       Execute a flow from a project
-  cancel                        Cancel a flow execution
-  fetch_flow_execution          Fetch a flow execution
-  resume_flow_execution         Resume a flow execution
-  fetch_flow_execution_updates  Fetch flow execution updates
-  fetch_execution_of_a_flow     Fetch all execution of a given flow
-  fetch_jobs_from_flow          Fetch jobs of a flow
-  fetch_execution_job_log       Fetches the correponding job logs
-  fetch_projects                Fetch all project from a user
-  fetch_sla                     Fetch the SLA from a schedule
-  login                         Login to an Azkaban server
-  logout                        Logout from Azkaban session
-  remove_permission             Remove group permission from a project
-  schedule                      Schedule a flow from a project with specified cron...
-  unschedule                    Unschedule a flow from a project
-  upload                        Generates a zip of path passed as argument and...
+  add_permission                      Add a group with permission in a project
+  change_permission                   Change a group permission in a project
+  create                              Create a new project
+  delete                              Delete a project
+  execute                             Execute a flow from a project
+  cancel                              Cancel a flow execution
+  fetch_running_executions_of_a_flow  Fetch the current running executions of a flow
+  fetch_flow_execution                Fetch a flow execution
+  fetch_flow_execution_updates        Fetch flow execution updates
+  fetch_execution_of_a_flow           Fetch all execution of a given flow
+  fetch_jobs_from_flow                Fetch jobs of a flow
+  fetch_execution_job_log             Fetches the correponding job logs
+  fetch_projects                      Fetch all project from a user
+  fetch_sla                           Fetch the SLA from a schedule
+  login                               Login to an Azkaban server
+  logout                              Logout from Azkaban session
+  remove_permission                   Remove group permission from a project
+  schedule                            Schedule a flow from a project with specified cron...
+  unschedule                          Unschedule a flow from a project
+  upload                              Generates a zip of path passed as argument and...
 ```
 
 ## Examples

--- a/azkaban_cli/api.py
+++ b/azkaban_cli/api.py
@@ -617,7 +617,7 @@ def resume_flow_execution(session, host, session_id, exec_id):
     response = session.get(
             u'session.id': session_id,
             u'ajax': 'resumeFlow',
-            u'execid': exec_id
+            u'execid': exec_id,
             u'ajax': 'getRunning',
             u'project': project,
             u'flow': flow

--- a/azkaban_cli/api.py
+++ b/azkaban_cli/api.py
@@ -576,8 +576,8 @@ def fetch_execution_job_log_request(session, host, session_id, exec_id, jobid, o
     :type jobid: str
     :param offset: The offset for the log data.
     :type offset: str
-    :param length: The length of the log data. For example, if the offset set is 
-     10 and the length is 1000, the returned log will starts from the 10th character 
+    :param length: The length of the log data. For example, if the offset set is
+     10 and the length is 1000, the returned log will starts from the 10th character
      and has a length of 1000 (less if the remaining log is less than 1000 long)
     :type length: str
     :raises FetchExecutionJobsLogError: when Azkaban api returns error in response
@@ -607,17 +607,43 @@ def resume_flow_execution(session, host, session_id, exec_id):
     :param str host: Hostname where the request should go
     :param str session_id: An id that the user should have when is logged in
     :param str exec_id: Execution id to be fetched
+    :param str session_id: An id that the user should have when is logged in
+    :param str project: Project name that will receive the newly updated group permissions on Azkaban
+    :param str project: Flow id whose executions will be fetched on Azkaban
     :return: The response from the request made
     :rtype: requests.Response
     :raises requests.exceptions.ConnectionError: if cannot connect to host
     """
-    
     response = session.get(
-        host + '/executor',
-        params={
             u'session.id': session_id,
             u'ajax': 'resumeFlow',
             u'execid': exec_id
+            u'ajax': 'getRunning',
+            u'project': project,
+            u'flow': flow
+        }
+    )
+
+    logging.debug("Response: \n%s", response.text)
+
+    return response
+
+    def fetch_running_executions_of_a_flow_request(session_id, project, flow):
+    """Fetch running executions of a flow
+
+    :param str session_id: An id that the user should have when is logged in
+    :param str project: Project name that will receive the newly updated group permissions on Azkaban
+    :param str project: Flow id whose executions will be fetched on Azkaban
+    :return: The response from the request made
+    :rtype: requests.Response
+    :raises requests.exceptions.ConnectionError: if cannot connect to host
+    """
+
+    response = session.get(
+            u'session.id': session_id,
+            u'ajax': 'getRunning',
+            u'project': project,
+            u'flow': flow
         }
     )
 

--- a/azkaban_cli/api.py
+++ b/azkaban_cli/api.py
@@ -615,6 +615,8 @@ def resume_flow_execution(session, host, session_id, exec_id):
     :raises requests.exceptions.ConnectionError: if cannot connect to host
     """
     response = session.get(
+        host + '/executor',
+        params={
             u'session.id': session_id,
             u'ajax': 'resumeFlow',
             u'execid': exec_id,
@@ -641,6 +643,8 @@ def fetch_running_executions_of_a_flow_request(session, host, session_id, projec
     """
 
     response = session.get(
+        host + '/executor',
+        params={
             u'session.id': session_id,
             u'ajax': 'getRunning',
             u'project': project,

--- a/azkaban_cli/api.py
+++ b/azkaban_cli/api.py
@@ -628,7 +628,8 @@ def resume_flow_execution(session, host, session_id, exec_id):
 
     return response
 
-    def fetch_running_executions_of_a_flow_request(session_id, project, flow):
+def fetch_running_executions_of_a_flow_request(session, host, session_id, project, flow):
+
     """Fetch running executions of a flow
 
     :param str session_id: An id that the user should have when is logged in

--- a/azkaban_cli/api.py
+++ b/azkaban_cli/api.py
@@ -619,10 +619,7 @@ def resume_flow_execution(session, host, session_id, exec_id):
         params={
             u'session.id': session_id,
             u'ajax': 'resumeFlow',
-            u'execid': exec_id,
-            u'ajax': 'getRunning',
-            u'project': project,
-            u'flow': flow
+            u'execid': exec_id
         }
     )
 

--- a/azkaban_cli/azkaban.py
+++ b/azkaban_cli/azkaban.py
@@ -33,6 +33,7 @@ from azkaban_cli.exceptions import (
     FetchExecutionsOfAFlowError,
     FetchExecutionJobsLogError,
     ResumeFlowExecutionError
+    FetchRunningExecutionsOfAFlowError
 )
 
 
@@ -762,8 +763,8 @@ class Azkaban(object):
         :type jobid: str
         :param offset: The offset for the log data.
         :type offset: str
-        :param length: The length of the log data. For example, if the offset set is 
-         10 and the length is 1000, the returned log will starts from the 10th character 
+        :param length: The length of the log data. For example, if the offset set is
+         10 and the length is 1000, the returned log will starts from the 10th character
          and has a length of 1000 (less if the remaining log is less than 1000 long)
         :type length: str
         :raises FetchExecutionJobsLogError: when Azkaban api returns error in response
@@ -805,3 +806,29 @@ class Azkaban(object):
 
         return response.json()
 
+    def fetch_running_executions_of_a_flow(self, project, flow):
+        """Fetch running executions of a flow command, intended to make the request to Azkaban
+        and treat the response properly.
+
+        This method receives the project name and the flow id, making the fetch and evaluating the response.
+
+        Returns the json response from the request.
+
+        :param project: Project name on Azkaban
+        :type project: str
+        :param flow: Flow id on Azkaban
+        :type flow: str
+        :raises FetchRunningExecutionsOfAFlowError: when Azkaban api returns error in response
+        """
+
+        self.__check_if_logged()
+
+        response = api.fetch_running_executions_of_a_flow_request(
+            self.__session_id,
+            project,
+            flow,
+        )
+
+        self.__catch_response_error(response, FetchRunningExecutionsOfAFlowError)
+
+        return response.json()

--- a/azkaban_cli/azkaban.py
+++ b/azkaban_cli/azkaban.py
@@ -824,6 +824,8 @@ class Azkaban(object):
         self.__check_if_logged()
 
         response = api.fetch_running_executions_of_a_flow_request(
+            self.__session,
+            self.__host,
             self.__session_id,
             project,
             flow,

--- a/azkaban_cli/azkaban.py
+++ b/azkaban_cli/azkaban.py
@@ -32,7 +32,7 @@ from azkaban_cli.exceptions import (
     FetchFlowExecutionUpdatesError,
     FetchExecutionsOfAFlowError,
     FetchExecutionJobsLogError,
-    ResumeFlowExecutionError
+    ResumeFlowExecutionError,
     FetchRunningExecutionsOfAFlowError
 )
 

--- a/azkaban_cli/azkaban_cli.py
+++ b/azkaban_cli/azkaban_cli.py
@@ -669,7 +669,7 @@ def fetch_execution_job_log(ctx, execution_id, jobid, offset, length):
 @click.argument(u'flow', type=click.STRING)
 def fetch_running_executions_of_a_flow(ctx, project, flow):
     """ Fetch running executions of a flow"""
-    _fetch_running_executions_of_a_flow(ctz, project, flow)
+    _fetch_running_executions_of_a_flow(ctx, project, flow)
 
 
 cli.add_command(login)

--- a/azkaban_cli/azkaban_cli.py
+++ b/azkaban_cli/azkaban_cli.py
@@ -31,7 +31,8 @@ from azkaban_cli.exceptions import (
     FetchFlowExecutionUpdatesError,
     FetchExecutionsOfAFlowError,
     FetchExecutionJobsLogError,
-    ResumeFlowExecutionError
+    ResumeFlowExecutionError,
+    FetchRunningExecutionsOfAFlowError
 )
 from azkaban_cli.__version__ import __version__
 
@@ -462,6 +463,18 @@ def __resume_flow_execution(ctx, execution_id):
         json = azkaban.resume_flow_execution(execution_id)
         logging.info('Flow successfully resumed')
     except ResumeFlowExecutionError as e:
+
+def __log_running_executions_of_a_flow(json):
+    logging.info('ExecIds: %s' % (json.get('execIds')))
+
+@login_requred
+def _fetch_running_executions_of_a_flow(ctx, project, flow):
+    azkaban = ctx.obj[u'azkaban']
+
+    try:
+        json = azkaban.fetch_running_executions_of_a_flow(ctx, project, flow)
+        __log_running_executions_of_a_flow(json)
+    except FetchRunningExecutionsOfAFlowError as e:
         logging.error(str(e))
 
 
@@ -650,6 +663,15 @@ def fetch_execution_job_log(ctx, execution_id, jobid, offset, length):
     """Fetch flow execution job logs"""
     __fetch_execution_job_log(ctx, execution_id, jobid, offset, length)
 
+@click.command(u'fetch_running_executions_of_a_flow')
+@click.pass_context
+@click.argument(u'project', type=click.STRING)
+@click.argument(u'flow', type=click.STRING)
+def fetch_running_executions_of_a_flow(ctx, project, flow):
+    """ Fetch running executions of a flow"""
+    _fetch_running_executions_of_a_flow(ctz, project, flow)
+
+
 cli.add_command(login)
 cli.add_command(logout)
 cli.add_command(upload)
@@ -669,8 +691,8 @@ cli.add_command(fetch_flow_execution)
 cli.add_command(fetch_flow_execution_updates)
 cli.add_command(fetch_executions_of_a_flow)
 cli.add_command(fetch_execution_job_log)
+cli.add_command(fetch_running_executions_of_a_flow)
 
-# ----------------------------------------------------------------------------------------------------------------------
 # Interface
 # ----------------------------------------------------------------------------------------------------------------------
 

--- a/azkaban_cli/exceptions.py
+++ b/azkaban_cli/exceptions.py
@@ -65,3 +65,6 @@ class FetchExecutionJobsLogError(Exception):
 
 class ResumeFlowExecutionError(Exception):
     pass
+
+class FetchRunningExecutionsOfAFlowError(Exception):
+    pass

--- a/azkaban_cli/tests/test_azkaban/test_fetch_running_executions_of_a_flow.py
+++ b/azkaban_cli/tests/test_azkaban/test_fetch_running_executions_of_a_flow.py
@@ -1,0 +1,66 @@
+from unittest import TestCase
+from unittest.mock import patch, ANY
+import os
+
+import responses
+
+import azkaban_cli.azkaban
+from azkaban_cli.exceptions import SessionError
+
+
+class AzkabanFetchRunningExecutionsOfAFlowTest(TestCase):
+    def setUp(self):
+        """
+        Creates an Azkaban instance and set a logged session for all fetch running executions of a flow tests.
+        """
+
+        self.azk = azkaban_cli.azkaban.Azkaban()
+
+        self.host = 'http://azkaban-mock.com'
+        self.user = 'username'
+        self.session_id = 'aebe406b-d5e6-4056-add6-bf41091e42c6'
+
+        self.azk.set_logged_session(self.host, self.user, self.session_id)
+
+        self.project = 'ProjectTest'
+        self.flow = 'testFlowName'
+
+    @responses.activate
+    def test_fetch_running_executions_of_a_flow(self):
+        """
+        Test fetch running executions of a flow method from Azkaban class
+        """
+
+        responses.add(
+            responses.GET,
+            self.host + "/executor",
+            json={
+                'project': self.project,
+                'flow': self.flow
+            },
+            status=200
+        )
+
+        self.azk.fetch_running_executions_of_a_flow(self.project, self.flow)
+
+    @patch('azkaban_cli.azkaban.api.fetch_running_executions_of_a_flow_request')
+    def test_fetch_running_executions_request_called(self, mock_fetch_running_executions_of_a_flow_request):
+        """
+        Test if fetch running executions of a flow method from Azkaban class is calling fetch it's request with expected arguments
+        """
+
+        self.azk.fetch_running_executions_of_a_flow(self.project, self.flow)
+
+        mock_fetch_running_executions_of_a_flow_request.assert_called_with(ANY, self.host, self.session_id, self.project, self.flow)
+
+    @responses.activate
+    def test_error_session_expired_fetch_executions_of_a_flow(self):
+        """
+        Test if fetch runnning executions of a flow method from Azkaban class raises SessionError if request returns error caused by session expired
+        """
+
+        fixture_path = os.path.join(os.path.dirname(__file__), os.pardir, "fixtures", "session_expired.html")
+        with open(fixture_path) as f:
+            responses.add(responses.GET, self.host + "/executor", json={"error": "session"}, status=200)
+        with self.assertRaises(SessionError):
+            self.azk.fetch_running_executions_of_a_flow(self.project, self.flow)


### PR DESCRIPTION
Add the API Call, according to the [docs](https://azkaban.readthedocs.io/en/latest/ajaxApi.html#fetch-running-executions-of-a-flow)

If anything seems wrong, please let me know (:1st_place_medal: 
